### PR TITLE
agregando stripe a compra de membresia por Id

### DIFF
--- a/src/membresias/membresia.controller.ts
+++ b/src/membresias/membresia.controller.ts
@@ -61,6 +61,13 @@ export class MembresiaController {
       if (!membresia.activa) {
         throw new HttpException('Esta membresía ya no está disponible', HttpStatus.BAD_REQUEST);
       }
+      
+// Crear la sesión de pago con Stripe
+const session = await this.stripeService.crearSesionDePago(
+    membresiaId,
+    membresia.precio,
+    usuario.email,
+  );
     
       usuario.membresia = membresia;
       await this.usuariosService.update(usuario);


### PR DESCRIPTION
agregando stripe a endpoint de membresia de compra de la misma por medio de id. Falta usar link de endpoint en front para chequear su correcto reflejo de pago por stripe 